### PR TITLE
feat: Landing Page Deployment-Konfiguration

### DIFF
--- a/landing/Dockerfile
+++ b/landing/Dockerfile
@@ -14,7 +14,7 @@ COPY . .
 RUN npm run build
 
 FROM nginx:alpine
-COPY --from=build /app/dist /usr/share/nginx/html/landing
+COPY --from=build /app/dist /usr/share/nginx/html
 COPY nginx.conf /etc/nginx/conf.d/default.conf
 EXPOSE 80
 CMD ["nginx", "-g", "daemon off;"]


### PR DESCRIPTION
## Summary
- Dockerfile und GitHub Action für Landing Page Deployment hinzugefügt
- Landing Page in Unterordner `landing/` verschoben
- Fix: nginx serve path von `/landing` auf root (`/usr/share/nginx/html`) korrigiert

## Test plan
- [ ] GitHub Action baut Docker Image nach Merge in `main`
- [ ] Landing Page ist unter der konfigurierten Domain erreichbar