### PR TITLE
fix: fehlende Build-Stage im Frontend Dockerfile

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,7 +1,11 @@
+FROM node:20-alpine AS build
+WORKDIR /app
+COPY package*.json ./
+RUN npm ci
+COPY . .
+RUN npm run build
+
 FROM nginx:alpine
-
 COPY --from=build /app/dist /usr/share/nginx/html
-
-EXPOSE 3000
-
+EXPOSE 80
 CMD ["nginx", "-g", "daemon off;"]

--- a/landing/Dockerfile
+++ b/landing/Dockerfile
@@ -14,7 +14,7 @@ COPY . .
 RUN npm run build
 
 FROM nginx:alpine
-COPY --from=build /app/dist /usr/share/nginx/html
+COPY --from=build /app/dist /usr/share/nginx/html/
 COPY nginx.conf /etc/nginx/conf.d/default.conf
 EXPOSE 80
 CMD ["nginx", "-g", "daemon off;"]


### PR DESCRIPTION
## Summary
- Frontend Dockerfile hatte keine Build-Stage — `COPY --from=build` schlug fehl
- Multi-stage Build mit `node:20-alpine AS build` ergänzt
- Port von 3000 auf 80 (nginx default) korrigiert

## Root Cause
Das Dockerfile enthielt nur die nginx-Stage, aber keine vorherige Stage namens `build`, weshalb Docker versuchte das Image `build:latest` von Docker Hub zu pullen.