### PR TITLE
fix: doppelten Slash in Bild-Pfaden der Landing Page entfernen

### DIFF
--- a/landing/src/components/Header.tsx
+++ b/landing/src/components/Header.tsx
@@ -23,7 +23,7 @@ export default function Header() {
     <header className={styles.header}>
       <div className={styles.inner}>
         <a href="/" className={styles.logo}>
-          <img src={`${import.meta.env.BASE_URL}/logo.svg`} alt="ReStockOffice" height={160} />
+          <img src={`${import.meta.env.BASE_URL}logo.svg`} alt="ReStockOffice" height={160} />
         </a>
         <nav className={styles.nav}>
           {NAV_LINKS.map(({ href, label }) => (

--- a/landing/src/components/HeroSection.tsx
+++ b/landing/src/components/HeroSection.tsx
@@ -65,7 +65,7 @@ export default function HeroSection() {
           <BuildingIllustration />
           <img
             ref={birdRef}
-            src={`${import.meta.env.BASE_URL}/logo-icon.svg`}
+            src={`${import.meta.env.BASE_URL}logo-icon.svg`}
             alt=""
             className={styles.bird}
             aria-hidden


### PR DESCRIPTION
## Problem
`import.meta.env.BASE_URL` gibt `/` zurück (da `base: '/'` in vite.config.ts).
Template-Literal `${BASE_URL}/logo.svg` erzeugte `//logo.svg` → Browser interpretierte `logo.svg` als Hostname.

## Fix
Führenden `/` vor den Dateinamen entfernt:
- `Header.tsx`: `logo.svg`
- `HeroSection.tsx`: `logo-icon.svg`