### PR TITLE
fix: Keycloak URL auf id.restockoffice.de korrigieren

### DIFF
--- a/.github/workflows/landing-docker.yml
+++ b/.github/workflows/landing-docker.yml
@@ -36,6 +36,6 @@ jobs:
             ghcr.io/${{ github.repository_owner }}/restockoffice-landing:latest
             ghcr.io/${{ github.repository_owner }}/restockoffice-landing:${{ github.sha }}
           build-args: |
-            VITE_KEYCLOAK_URL=https://auth.restockoffice.com
+            VITE_KEYCLOAK_URL=https://id.restockoffice.de
             VITE_KEYCLOAK_REALM=restock-office
             VITE_KEYCLOAK_CLIENT_ID=restock-office-web

--- a/landing/Dockerfile
+++ b/landing/Dockerfile
@@ -1,7 +1,7 @@
 FROM node:20-alpine AS build
 WORKDIR /app
 
-ARG VITE_KEYCLOAK_URL=https://auth.restockoffice.com
+ARG VITE_KEYCLOAK_URL=https://id.restockoffice.de
 ARG VITE_KEYCLOAK_REALM=restock-office
 ARG VITE_KEYCLOAK_CLIENT_ID=restock-office-web
 ENV VITE_KEYCLOAK_URL=$VITE_KEYCLOAK_URL


### PR DESCRIPTION
## Summary
- `VITE_KEYCLOAK_URL` war auf `auth.restockoffice.com` gesetzt, dieser Host existiert nicht
- Korrekter Nginx Proxy Manager Eintrag ist `id.restockoffice.de` → `restockoffice-keycloak:8080`
- Fix in `landing/Dockerfile` und `.github/workflows/landing-docker.yml`

## Test plan
- [ ] PR mergen → GitHub Actions baut neues Landing Image
- [ ] Auf dem Server: `docker compose pull && docker compose up -d` im landing Verzeichnis
- [ ] "Registrieren" auf restockoffice.de testen