### PR TITLE
fix: KC_PROXY auf KC_PROXY_HEADERS aktualisieren (Keycloak 24+ API)

### DIFF
--- a/keycloak/docker-compose.yml
+++ b/keycloak/docker-compose.yml
@@ -7,6 +7,10 @@ services:
     environment:
       KEYCLOAK_ADMIN: admin
       KEYCLOAK_ADMIN_PASSWORD: admin
+      KC_HOSTNAME: id.restockoffice.de
+      KC_HOSTNAME_STRICT: "false"
+      KC_PROXY_HEADERS: xforwarded
+      KC_HTTP_ENABLED: "true"
     ports:
       - "8180:8080"
     volumes:


### PR DESCRIPTION
## Summary
- Ersetzt veraltetes `KC_PROXY=edge` durch `KC_PROXY_HEADERS=xforwarded` (neue API seit Keycloak 24+)
- Fügt `KC_HTTP_ENABLED=true` hinzu, damit Keycloak intern HTTP akzeptiert während Nginx SSL übernimmt
- Behebt den iframe-Timeout-Fehler ("somethingWentWrong") in der Keycloak Admin Console

## Nach dem Merge
Auf dem Server ausführen:
```bash
cd keycloak
docker compose down && docker compose up -d
```