### PR TITLE
fix: logo-icon.svg als Favicon verwenden

### DIFF
--- a/landing/index.html
+++ b/landing/index.html
@@ -2,8 +2,8 @@
 <html lang="de">
   <head>
     <meta charset="UTF-8" />
-    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
-    <link rel="shortcut icon" href="/favicon.svg" />
+    <link rel="icon" type="image/svg+xml" href="/logo-icon.svg" />
+    <link rel="shortcut icon" href="/logo-icon.svg" />
     <link rel="apple-touch-icon" href="/logo-icon.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="description" content="ReStockOffice – Büromaterial automatisch und pünktlich. Nie wieder leer." />


### PR DESCRIPTION
## Summary
- Ersetzt den falschen Placeholder-Favicon durch das echte ReStockOffice Logo (logo-icon.svg)