### PR TITLE
fix: Redirect-URIs auf restockoffice.de korrigieren

### DIFF
--- a/keycloak/realm-config.json
+++ b/keycloak/realm-config.json
@@ -19,18 +19,18 @@
       "publicClient": true,
       "standardFlowEnabled": true,
       "directAccessGrantsEnabled": false,
-      "rootUrl": "https://restockoffice.com/landing",
-      "baseUrl": "https://restockoffice.com/landing",
+      "rootUrl": "https://restockoffice.de",
+      "baseUrl": "https://restockoffice.de",
       "redirectUris": [
-        "https://restockoffice.com/landing",
-        "https://restockoffice.com/landing/*",
-        "http://localhost:5173/landing",
-        "http://localhost:5173/landing/*",
-        "http://localhost:5174/landing",
-        "http://localhost:5174/landing/*"
+        "https://restockoffice.de",
+        "https://restockoffice.de/*",
+        "http://localhost:5173",
+        "http://localhost:5173/*",
+        "http://localhost:5174",
+        "http://localhost:5174/*"
       ],
       "webOrigins": [
-        "https://restockoffice.com",
+        "https://restockoffice.de",
         "http://localhost:5173",
         "http://localhost:5174",
         "+"


### PR DESCRIPTION
## Summary
- Korrigiert falsche Redirect-URIs von `restockoffice.com/landing` auf `restockoffice.de`
- Pfad von `/landing` auf `/` angepasst (Landing Page läuft seit fc3d86d unter /)