### PR TITLE
✨ Landing Page Überarbeitung & Restocker-Sektion

### DIFF
--- a/landing/package-lock.json
+++ b/landing/package-lock.json
@@ -1,5 +1,5 @@
 {
- "name": "ReStockOffice",
+ "name": "landing",
  "lockfileVersion": 3,
  "requires": true,
  "packages": {

--- a/landing/src/components/CtaSection.tsx
+++ b/landing/src/components/CtaSection.tsx
@@ -9,7 +9,7 @@ export default function CtaSection() {
           Starten Sie noch heute!<br />
         </h2>
         <p className={styles.subtitle}>
-          30 Tage gratis testen. Kein Risiko, keine Kreditkarte.
+          Jetzt loslegen und Büromaterial smarter verwalten.
         </p>
         <button className={styles.cta} onClick={redirectToRegister}>
           Jetzt registrieren

--- a/landing/src/components/FeaturesSection.tsx
+++ b/landing/src/components/FeaturesSection.tsx
@@ -9,39 +9,39 @@ type Feature = {
 
 const features: Feature[] = [
   {
-    icon: AutoIcon,
-    title: 'Automatische Nachbestellung',
+    icon: AboIcon,
+    title: 'Abo-Bestellungen',
     points: [
-      'Lagerstand wird laufend überwacht',
-      'Bestellung erfolgt bei Unterschreitung des Mindestbestands',
-      'Keine manuelle Eingriffe notwendig',
+      'Artikel einmalig auswählen und Intervall festlegen',
+      'Automatische Lieferung ohne manuelles Nachbestellen',
+      'Bereits abonnierte Artikel sind klar gekennzeichnet',
     ],
   },
   {
-    icon: DashboardIcon,
-    title: 'Übersichtliches Dashboard',
+    icon: DeliveryIcon,
+    title: 'Zuverlässige Lieferung',
     points: [
-      'Alle Artikel auf einen Blick',
-      'Status je Produkt in Echtzeit',
-      'Bestellhistorie & Auswertungen',
+      'Lieferankündigung 2 Tage vor dem Liefertermin',
+      'Restocker bringt die Ware direkt ins Büro',
+      'Bestätigung per Mail nach erfolgreicher Lieferung',
     ],
   },
   {
-    icon: SupplierIcon,
-    title: 'Flexible Lieferantenanbindung',
+    icon: OverviewIcon,
+    title: 'Übersicht & Transparenz',
     points: [
-      'Mehrere Lieferanten gleichzeitig',
-      'Preisvergleich automatisiert',
-      'Eigene Verträge bleiben erhalten',
+      'Alle aktiven Abos auf einen Blick',
+      'Bevorstehende Lieferungen im Dashboard',
+      'Vollständige Lieferhistorie abrufbar',
     ],
   },
   {
-    icon: TeamIcon,
-    title: 'Teamverwaltung',
+    icon: AccountIcon,
+    title: 'Einfache Kontoverwaltung',
     points: [
-      'Rollen & Berechtigungen',
-      'Freigabeprozesse konfigurierbar',
-      'Abteilungsweises Budgetmanagement',
+      'Öffnungszeiten hinterlegen für die Lieferung',
+      'Abos jederzeit einsehbar',
+      'Benachrichtigungen per Mail inklusive',
     ],
   },
 ]
@@ -52,10 +52,9 @@ export default function FeaturesSection() {
       <div className="container">
         <div className={styles.header}>
           <span className={styles.label}>Vorteile</span>
-          <h2 className={styles.title}>Alles, was Ihr Büro braucht</h2>
+          <h2 className={styles.title}>Büromaterial auf Autopilot</h2>
           <p className={styles.subtitle}>
-            Von der Bestandsüberwachung bis zur Lieferung –
-            ReStockOffice übernimmt den gesamten Prozess.
+            Einmal abonnieren – ReStockOffice kümmert sich um den Rest.
           </p>
         </div>
         <ul className={styles.grid}>
@@ -79,7 +78,7 @@ export default function FeaturesSection() {
   )
 }
 
-function AutoIcon() {
+function AboIcon() {
   return (
     <svg width="28" height="28" viewBox="0 0 28 28" fill="none" aria-hidden>
       <path d="M14 4v4M14 20v4M4 14h4M20 14h4" stroke="currentColor" strokeWidth="2" strokeLinecap="round"/>
@@ -89,18 +88,7 @@ function AutoIcon() {
   )
 }
 
-function DashboardIcon() {
-  return (
-    <svg width="28" height="28" viewBox="0 0 28 28" fill="none" aria-hidden>
-      <rect x="4" y="4" width="8" height="8" rx="2" stroke="currentColor" strokeWidth="2"/>
-      <rect x="16" y="4" width="8" height="8" rx="2" stroke="currentColor" strokeWidth="2"/>
-      <rect x="4" y="16" width="8" height="8" rx="2" stroke="currentColor" strokeWidth="2"/>
-      <rect x="16" y="16" width="8" height="8" rx="2" stroke="currentColor" strokeWidth="2"/>
-    </svg>
-  )
-}
-
-function SupplierIcon() {
+function DeliveryIcon() {
   return (
     <svg width="28" height="28" viewBox="0 0 28 28" fill="none" aria-hidden>
       <path d="M4 8h14l3 8H7L4 8Z" stroke="currentColor" strokeWidth="2" strokeLinejoin="round"/>
@@ -111,13 +99,22 @@ function SupplierIcon() {
   )
 }
 
-function TeamIcon() {
+function OverviewIcon() {
   return (
     <svg width="28" height="28" viewBox="0 0 28 28" fill="none" aria-hidden>
-      <circle cx="10" cy="10" r="4" stroke="currentColor" strokeWidth="2"/>
-      <path d="M3 24c0-3.866 3.134-7 7-7s7 3.134 7 7" stroke="currentColor" strokeWidth="2" strokeLinecap="round"/>
-      <circle cx="21" cy="10" r="3" stroke="currentColor" strokeWidth="2"/>
-      <path d="M25 24c0-3.314-1.79-6-4-6" stroke="currentColor" strokeWidth="2" strokeLinecap="round"/>
+      <rect x="4" y="4" width="8" height="8" rx="2" stroke="currentColor" strokeWidth="2"/>
+      <rect x="16" y="4" width="8" height="8" rx="2" stroke="currentColor" strokeWidth="2"/>
+      <rect x="4" y="16" width="8" height="8" rx="2" stroke="currentColor" strokeWidth="2"/>
+      <rect x="16" y="16" width="8" height="8" rx="2" stroke="currentColor" strokeWidth="2"/>
+    </svg>
+  )
+}
+
+function AccountIcon() {
+  return (
+    <svg width="28" height="28" viewBox="0 0 28 28" fill="none" aria-hidden>
+      <circle cx="14" cy="10" r="4" stroke="currentColor" strokeWidth="2"/>
+      <path d="M6 24c0-4.418 3.582-8 8-8s8 3.582 8 8" stroke="currentColor" strokeWidth="2" strokeLinecap="round"/>
     </svg>
   )
 }

--- a/landing/src/components/Footer.tsx
+++ b/landing/src/components/Footer.tsx
@@ -1,66 +1,12 @@
 import styles from './Footer.module.css'
 
-const PAYMENT_METHODS = [
-  { label: 'Apple Pay',   icon: <ApplePayIcon /> },
-  { label: 'PayPal',      icon: <PayPalIcon /> },
-  { label: 'Klarna',      icon: <KlarnaIcon /> },
-  { label: 'Kreditkarte', icon: <CreditCardIcon /> },
-]
-
 export default function Footer() {
   const year = new Date().getFullYear()
   return (
     <footer className={styles.footer}>
       <div className={`container ${styles.inner}`}>
-        <div className={styles.payments}>
-          {PAYMENT_METHODS.map(({ label, icon }) => (
-            <div key={label} className={styles.paymentBadge} aria-label={label}>
-              {icon}
-            </div>
-          ))}
-        </div>
         <p className={styles.copy}>© {year} ReStockOffice</p>
       </div>
     </footer>
-  )
-}
-
-function ApplePayIcon() {
-  return (
-    <svg width="64" height="38" viewBox="0 0 64 38" fill="none" aria-hidden>
-      <rect width="64" height="38" rx="6" fill="#000"/>
-      <path d="M20.5 13.2c.7-.9 1.2-2 1.1-3.2-1.1.1-2.4.7-3.2 1.6-.7.8-1.3 2-1.1 3.1 1.2.1 2.4-.5 3.2-1.5Z" fill="#fff"/>
-      <path d="M21.6 14.8c-1.8-.1-3.3 1-4.1 1-.9 0-2.2-1-3.6-.9-1.8 0-3.5 1.1-4.5 2.7-1.9 3.3-.5 8.2 1.4 10.9.9 1.4 2 2.8 3.5 2.7 1.4 0 1.9-.9 3.6-.9s2.1.9 3.6.9c1.5 0 2.5-1.3 3.4-2.7 1-1.5 1.5-2.9 1.5-3 0 0-2.9-1.1-2.9-4.3 0-2.7 2.2-4 2.3-4-1.2-1.9-3.1-2.3-4.2-2.4Z" fill="#fff"/>
-      <text x="46" y="24" fill="#fff" fontSize="12" fontWeight="600" fontFamily="system-ui, sans-serif" textAnchor="middle">Pay</text>
-    </svg>
-  )
-}
-
-function PayPalIcon() {
-  return (
-    <svg width="64" height="38" viewBox="0 0 64 38" fill="none" aria-hidden>
-      <rect width="64" height="38" rx="6" fill="#fff" stroke="#e6e6e6"/>
-      <text x="32" y="24" fill="#003087" fontSize="13" fontWeight="800" fontFamily="system-ui, sans-serif" textAnchor="middle">PayPal</text>
-    </svg>
-  )
-}
-
-function KlarnaIcon() {
-  return (
-    <svg width="64" height="38" viewBox="0 0 64 38" fill="none" aria-hidden>
-      <rect width="64" height="38" rx="6" fill="#FFB3C7"/>
-      <text x="32" y="24" fill="#0A0A0A" fontSize="13" fontWeight="700" fontFamily="system-ui, sans-serif" textAnchor="middle">Klarna</text>
-    </svg>
-  )
-}
-
-function CreditCardIcon() {
-  return (
-    <svg width="64" height="38" viewBox="0 0 64 38" fill="none" aria-hidden>
-      <rect width="64" height="38" rx="6" fill="#fff" stroke="#e6e6e6"/>
-      <circle cx="36" cy="19" r="8" fill="#F79E1B"/>
-      <circle cx="28" cy="19" r="8" fill="#EB001B" opacity="0.9"/>
-      <path d="M32 12.8a8 8 0 0 1 0 12.4A8 8 0 0 1 32 12.8Z" fill="#FF5F00"/>
-    </svg>
   )
 }

--- a/landing/src/components/Header.tsx
+++ b/landing/src/components/Header.tsx
@@ -34,6 +34,7 @@ export default function Header() {
                 <span className={styles.userName}>
                   {auth.name ?? auth.email ?? 'Angemeldet'}
                 </span>
+                <a href="https://app.restockoffice.de" className="btn-primary">Zur App</a>
                 <button className="btn-outline" onClick={logout}>Abmelden</button>
               </>
             ) : (

--- a/landing/src/components/HeroSection.tsx
+++ b/landing/src/components/HeroSection.tsx
@@ -94,7 +94,7 @@ export default function HeroSection() {
             </svg>
           </button>
 
-          <p className={styles.trust}>Kostenlos testen · DSGVO-konform</p>
+          <p className={styles.trust}>DSGVO-konform</p>
         </div>
 
       </div>
@@ -113,13 +113,13 @@ const BuildingIllustration = memo(function BuildingIllustration() {
     >
       <rect x="130" y="60" width="140" height="220" rx="4" fill="#2B7A6A"/>
       <rect x="130" y="60" width="10" height="220" fill="#3d9e8a" opacity="0.4"/>
-      {[0,1,2,3,4,5].map(row =>
+      {[0,1,2,3,4].map(row =>
         [0,1,2,3].map(col => (
           <rect
             key={`w-${row}-${col}`}
             x={148 + col * 28} y={80 + row * 32}
             width={16} height={20} rx="2"
-            fill={row === 5 && col === 3 ? '#3EB89A' : row % 2 === col % 2 ? '#a8d8cc' : '#d4ede8'}
+            fill={row % 2 === col % 2 ? '#a8d8cc' : '#d4ede8'}
           />
         ))
       )}

--- a/landing/src/components/HowItWorksSection.tsx
+++ b/landing/src/components/HowItWorksSection.tsx
@@ -10,22 +10,22 @@ const steps: Step[] = [
   {
     number: '01',
     title: 'Konto erstellen',
-    description: 'Registrierung in unter 2 Minuten. Keine Kreditkarte, keine Vertragsbindung.',
+    description: 'Registrierung in unter 2 Minuten. Direkt loslegen, ohne Aufwand.',
   },
   {
     number: '02',
-    title: 'Artikel & Mindestbestände einrichten',
-    description: 'Legen Sie Ihre Büroartikel an und definieren Sie, ab wann nachbestellt werden soll.',
+    title: 'Artikel abonnieren',
+    description: 'Gewünschte Büroartikel auswählen und ein Lieferintervall festlegen – einmalig, fertig.',
   },
   {
     number: '03',
-    title: 'Lieferant verbinden',
-    description: 'Anbindung an Ihren bevorzugten Lieferanten – oder nutzen Sie unsere Partnernetzwerk.',
+    title: 'Öffnungszeiten hinterlegen',
+    description: 'Teilt uns eure Bürozeiten mit, damit der Restocker zur richtigen Zeit liefern kann.',
   },
   {
     number: '04',
-    title: 'Fertig – ReStockOffice übernimmt',
-    description: 'Das System überwacht Ihre Bestände und löst Bestellungen automatisch und rechtzeitig aus.',
+    title: 'Fertig – wir liefern automatisch',
+    description: 'ReStockOffice kündigt jede Lieferung rechtzeitig per Mail an und bestätigt die Ankunft.',
   },
 ]
 

--- a/landing/src/components/RestockerSection.module.css
+++ b/landing/src/components/RestockerSection.module.css
@@ -1,0 +1,193 @@
+.section {
+  padding: var(--section-padding);
+  background: var(--color-bg-subtle);
+}
+
+.inner {
+  display: grid;
+  grid-template-columns: 1fr 380px;
+  gap: 64px;
+  align-items: center;
+}
+
+.text {
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+}
+
+.label {
+  display: inline-block;
+  width: fit-content;
+  background: rgba(59, 107, 97, 0.1);
+  color: var(--color-primary);
+  font-weight: 600;
+  font-size: 0.8125rem;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  padding: 5px 14px;
+  border-radius: var(--radius-pill);
+}
+
+.title {
+  font-size: clamp(1.6rem, 3vw, 2.25rem);
+  font-weight: 800;
+  color: var(--color-primary);
+  line-height: 1.2;
+  margin: 0;
+}
+
+.accent {
+  color: var(--color-accent);
+}
+
+.desc {
+  font-size: 1.0625rem;
+  color: var(--color-text-muted);
+  line-height: 1.65;
+  max-width: 500px;
+  margin: 0;
+}
+
+.perks {
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  margin: 0;
+  padding: 0;
+}
+
+.perk {
+  display: flex;
+  align-items: flex-start;
+  gap: 10px;
+  font-size: 0.9375rem;
+  color: var(--color-text-muted);
+  line-height: 1.5;
+}
+
+.checkIcon {
+  flex-shrink: 0;
+  margin-top: 1px;
+  color: var(--color-accent);
+}
+
+.cta {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  background: var(--color-primary);
+  color: #fff;
+  font-size: 0.9375rem;
+  font-weight: 700;
+  padding: 13px 26px;
+  border-radius: var(--radius-pill);
+  border: none;
+  cursor: pointer;
+  text-decoration: none;
+  transition: background 0.2s, transform 0.15s;
+  width: fit-content;
+}
+.cta:hover {
+  background: var(--color-accent);
+  transform: translateY(-1px);
+}
+
+/* ── Earning card ── */
+.card {
+  background: var(--color-bg);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-lg);
+  padding: 36px 32px;
+  box-shadow: var(--shadow-hover);
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+
+.cardBadge {
+  display: inline-block;
+  width: fit-content;
+  background: rgba(59, 107, 97, 0.1);
+  color: var(--color-primary);
+  font-weight: 600;
+  font-size: 0.75rem;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  padding: 4px 12px;
+  border-radius: var(--radius-pill);
+}
+
+.earning {
+  display: flex;
+  align-items: baseline;
+  gap: 10px;
+}
+
+.earningAmount {
+  font-size: 3.5rem;
+  font-weight: 800;
+  color: var(--color-primary);
+  line-height: 1;
+}
+
+.earningUnit {
+  font-size: 1rem;
+  color: var(--color-text-muted);
+  font-weight: 500;
+}
+
+.exampleBox {
+  background: var(--color-bg-subtle);
+  border-radius: var(--radius-md);
+  padding: 20px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.exampleLabel {
+  font-size: 0.75rem;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--color-text-muted);
+  margin: 0 0 4px;
+}
+
+.exampleRow {
+  display: flex;
+  justify-content: space-between;
+  font-size: 0.9375rem;
+  color: var(--color-text-muted);
+}
+
+.exampleRow strong {
+  color: var(--color-primary);
+  font-weight: 700;
+}
+
+.exampleTotal {
+  border-top: 1px solid var(--color-border);
+  padding-top: 10px;
+  margin-top: 2px;
+  font-weight: 600;
+  color: var(--color-primary);
+}
+
+.exampleTotal strong {
+  font-size: 1.0625rem;
+  color: var(--color-accent);
+}
+
+/* ── Responsive ── */
+@media (max-width: 860px) {
+  .inner {
+    grid-template-columns: 1fr;
+    gap: 40px;
+  }
+  .card {
+    max-width: 420px;
+  }
+}

--- a/landing/src/components/RestockerSection.tsx
+++ b/landing/src/components/RestockerSection.tsx
@@ -1,0 +1,82 @@
+import styles from './RestockerSection.module.css'
+
+const CONTACT_MAIL = 'mim2665@thi.de'
+
+const perks = [
+  'Faire Vergütung: 7 € pro angefahrenem Unternehmen',
+  'Keine Vorkenntnisse nötig – einfache App-Führung',
+  'Stabile Routen durch wiederkehrende Abos',
+]
+
+const mailtoHref =
+  `mailto:${CONTACT_MAIL}` +
+  `?subject=${encodeURIComponent('Bewerbung als Restocker – ReStockOffice')}` +
+  `&body=${encodeURIComponent('Hallo,\n\nich möchte mich als Restocker bei ReStockOffice bewerben.\n\nMein Name: \nMeine Verfügbarkeit: \nKurze Vorstellung: \n\nMit freundlichen Grüßen')}`
+
+export default function RestockerSection() {
+  return (
+    <section id="restocker" className={styles.section}>
+      <div className={`container ${styles.inner}`}>
+        <div className={styles.text}>
+          <span className={styles.label}>Für Restocker</span>
+          <h2 className={styles.title}>
+            Du hältst Büros<br />
+            <span className={styles.accent}>Smart in Stock</span>
+          </h2>
+          <p className={styles.desc}>
+            Werde Teil des ReStockOffice-Teams und bring Büros in deiner Stadt
+            auf den neuesten Stand – fair bezahlt, unkompliziert und mit
+            einer App, die dich durch jeden Einsatz führt.
+          </p>
+          <ul className={styles.perks}>
+            {perks.map((p) => (
+              <li key={p} className={styles.perk}>
+                <CheckIcon />
+                {p}
+              </li>
+            ))}
+          </ul>
+          <a href={mailtoHref} className={styles.cta}>
+            Jetzt als Restocker bewerben
+            <svg width="18" height="18" viewBox="0 0 18 18" fill="none" aria-hidden>
+              <path d="M2 4h14v10H2z" stroke="currentColor" strokeWidth="2" strokeLinejoin="round"/>
+              <path d="M2 4l7 6 7-6" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"/>
+            </svg>
+          </a>
+        </div>
+
+        <div className={styles.card}>
+          <div className={styles.cardBadge}>Deine Vergütung</div>
+          <div className={styles.earning}>
+            <span className={styles.earningAmount}>7 €</span>
+            <span className={styles.earningUnit}>pro Unternehmen</span>
+          </div>
+          <div className={styles.exampleBox}>
+            <p className={styles.exampleLabel}>Beispielrechnung</p>
+            <div className={styles.exampleRow}>
+              <span>5 Unternehmen / Tag</span>
+              <strong>35 €</strong>
+            </div>
+            <div className={styles.exampleRow}>
+              <span>4 Tage / Woche</span>
+              <strong>140 €</strong>
+            </div>
+            <div className={`${styles.exampleRow} ${styles.exampleTotal}`}>
+              <span>Monatlich (ca.)</span>
+              <strong>560 €</strong>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+  )
+}
+
+function CheckIcon() {
+  return (
+    <svg width="18" height="18" viewBox="0 0 18 18" fill="none" aria-hidden className={styles.checkIcon}>
+      <circle cx="9" cy="9" r="9" fill="currentColor" opacity="0.15"/>
+      <path d="M5 9l3 3 5-5" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"/>
+    </svg>
+  )
+}

--- a/landing/src/keycloak.ts
+++ b/landing/src/keycloak.ts
@@ -28,14 +28,16 @@ export async function getAuthState(): Promise<{ authenticated: boolean; name?: s
   }
 }
 
+const APP_URL = 'https://app.restockoffice.de'
+
 export async function redirectToRegister(): Promise<void> {
   await init()
-  keycloak.register()
+  keycloak.register({ redirectUri: APP_URL })
 }
 
 export async function redirectToLogin(): Promise<void> {
   await init()
-  keycloak.login()
+  keycloak.login({ redirectUri: APP_URL })
 }
 
 export async function logout(): Promise<void> {

--- a/landing/src/pages/LandingPage.tsx
+++ b/landing/src/pages/LandingPage.tsx
@@ -3,6 +3,7 @@ import Header from '../components/Header'
 import HeroSection from '../components/HeroSection'
 
 const FeaturesSection   = lazy(() => import('../components/FeaturesSection'))
+const RestockerSection  = lazy(() => import('../components/RestockerSection'))
 const HowItWorksSection = lazy(() => import('../components/HowItWorksSection'))
 const Footer            = lazy(() => import('../components/Footer'))
 
@@ -15,6 +16,7 @@ export default function LandingPage() {
         <Suspense fallback={null}>
           <FeaturesSection />
           <HowItWorksSection />
+          <RestockerSection />
         </Suspense>
       </main>
       <Suspense fallback={null}>


### PR DESCRIPTION
## Summary
- Texte und Icons in Features-, HowItWorks-, Hero- und CTA-Section aktualisiert, um den tatsächlichen Produktfokus (Abo-Lieferung) widerzuspiegeln
- Footer auf Copyright-Zeile reduziert (Zahlungsarten entfernt)
- Header: „Zur App"-Link für eingeloggte Nutzer hinzugefügt
- Keycloak: `redirectUri` nach Login/Register auf `https://app.restockoffice.de` gesetzt
- Neue **RestockerSection**: spielt mit dem Slogan „Smart in Stock", zeigt Vergütung (7 € / Unternehmen) mit Beispielrechnung und öffnet per Mailto-Link eine vorausgefüllte Bewerbungsmail

## Test plan
- [ ] Landing Page lokal starten (`npm run dev` in `/landing`)
- [ ] Alle Sektionen auf Desktop und Mobile prüfen
- [ ] Restocker-Button öffnet E-Mail-Client mit vorausgefüllter Betreffzeile
- [ ] Login/Registrierung leitet korrekt auf `https://app.restockoffice.de` weiter